### PR TITLE
Replace 60/30/10 template with 50/30/20

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,14 +29,14 @@ Single test file: `npx vitest run path/to/file.test.ts` (or `path/to/Component.s
 
 ## What stblzr is
 
-stblzr is a simple ETF portfolio rebalancer for savings plans. A user maintains a small set of ETF/stock positions following a target allocation template (e.g. 60/30/10), enters their current holdings, and the app tells them the minimal set of buy/sell actions needed to bring the portfolio back to target.
+stblzr is a simple ETF portfolio rebalancer for savings plans. A user maintains a small set of ETF/stock positions following a target allocation template (e.g. 50/30/20), enters their current holdings, and the app tells them the minimal set of buy/sell actions needed to bring the portfolio back to target.
 
 Primary use case: mobile browsers — Safari on iOS and Chrome on Android. Favor simplicity and small bundle size over feature breadth; this informed the plain-SPA/no-framework setup above.
 
 ## Core product flow
 
 1. **Onboarding**: user picks a portfolio template. Only two are supported for now:
-   - 60/30/10
+   - 50/30/20
    - 70/30
 
    The chosen template is saved persistently (this is the only onboarding step).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stblzr
 
-A simple ETF portfolio rebalancer for savings plans. Pick a target allocation template (60/30/10 or 70/30), enter your current holdings, and get the minimal set of buy/sell actions needed to rebalance. Built as a Svelte + TypeScript PWA, aimed at mobile browsers (Safari on iOS, Chrome on Android).
+A simple ETF portfolio rebalancer for savings plans. Pick a target allocation template (50/30/20 or 70/30), enter your current holdings, and get the minimal set of buy/sell actions needed to rebalance. Built as a Svelte + TypeScript PWA, aimed at mobile browsers (Safari on iOS, Chrome on Android).
 
 See [CLAUDE.md](./CLAUDE.md) for architecture notes and [USER_STORIES.md](./USER_STORIES.md) for the requirements/backlog.
 

--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -6,13 +6,13 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 
 ## Onboarding
 
-- [ ] **US-1**: As a first-time user, I can choose a portfolio template (60/30/10 or 70/30) so the app knows my target allocation.
+- [ ] **US-1**: As a first-time user, I can choose a portfolio template (50/30/20 or 70/30) so the app knows my target allocation.
 - [ ] **US-2**: As a user, my chosen template is saved persistently (offline-capable, survives app restarts) so I don't have to re-select it every visit.
 - [ ] **US-3**: As a returning user with a saved template, I skip onboarding and go straight to my portfolio view.
 
 ## Target allocation view
 
-- [ ] **US-4**: As a user, I see a pie chart of my target allocation (e.g. 60/30/10 across the three portfolio parts) so I understand what I'm aiming for.
+- [ ] **US-4**: As a user, I see a pie chart of my target allocation (e.g. 50/30/20 across the three portfolio parts) so I understand what I'm aiming for.
 
 ## Current holdings input
 
@@ -29,5 +29,5 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 
 - Editing/removing individual ETF/stock line items within a portfolio.
 - Changing portfolio template after onboarding (and what happens to existing holdings data).
-- Support for portfolio templates beyond 60/30/10 and 70/30 (e.g. custom allocations).
+- Support for portfolio templates beyond 50/30/20 and 70/30 (e.g. custom allocations).
 - Historical tracking of rebalancing actions over time.


### PR DESCRIPTION
Replaces the 60/30/10 portfolio template with 50/30/20 across the project docs (CLAUDE.md, README.md, USER_STORIES.md). No code changes were needed since the project is still at the scaffolding stage.

Closes #2.

Generated with [Claude Code](https://claude.ai/code)