### PR TITLE
Fix: add safe-area gap above header for notch/camera

### DIFF
--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -67,7 +67,7 @@
 	.portfolio {
 		max-width: 28rem;
 		margin: 0 auto;
-		padding: 1.5rem 1rem;
+		padding: calc(1.5rem + env(safe-area-inset-top)) 1rem 1.5rem;
 		font-family:
 			system-ui,
 			-apple-system,

--- a/src/lib/components/TemplateSelector.svelte
+++ b/src/lib/components/TemplateSelector.svelte
@@ -39,7 +39,7 @@
 	.selector {
 		max-width: 28rem;
 		margin: 0 auto;
-		padding: 1.5rem 1rem;
+		padding: calc(1.5rem + env(safe-area-inset-top)) 1rem 1.5rem;
 		font-family:
 			system-ui,
 			-apple-system,


### PR DESCRIPTION
Adds a dynamic safe-area gap above the page headings so they aren't obscured by the front camera/notch/Dynamic Island on iPhone 15 and similar devices.

Uses `env(safe-area-inset-top)` (already enabled via `viewport-fit=cover` in app.html) added to the top padding of the portfolio and template-selector screens. Falls back to 0 on devices without a safe-area inset, so it works dynamically across common devices.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)