### PR TITLE
Add currency display and onboarding currency selection

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -10,6 +10,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 - [x] **US-2**: As a user, my chosen template is saved persistently (offline-capable, survives app restarts) so I don't have to re-select it every visit.
 - [x] **US-3**: As a returning user with a saved template, I skip onboarding and go straight to my portfolio view.
 - [ ] **US-13**: As a user, I can give each part of my split a name of my own choosing, saved persistently, so I still recognize what each allocation represents even after not checking my portfolio for a long time.
+- [x] **US-14**: As a user, I can choose my currency (Euro or US Dollar) on the onboarding screen, saved persistently, with Euro as the default, so my amounts are shown in the currency I actually use.
 
 ## Target allocation view
 
@@ -18,6 +19,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 ## Current holdings input
 
 - [x] **US-5**: As a user, I can enter the current currency amount I hold in each ETF/stock of my portfolio.
+- [x] **US-15**: As a user, all currency amounts I see are shown with the correct currency symbol and locale-appropriate separators (e.g. `1.234,56 €` for Euro, `$1,234.56` for US Dollar) based on my chosen currency.
 - [x] **US-6**: As a user, my entered holdings are saved persistently so I don't have to re-enter them every visit.
 - [x] **US-7**: As a user, once I've entered my holdings, I see an overlay on the pie chart with colored indicators showing which parts of my portfolio are over-weight and which are under-weight relative to target.
 

--- a/src/lib/components/HoldingsRow.svelte
+++ b/src/lib/components/HoldingsRow.svelte
@@ -22,14 +22,7 @@
 	<span class="name">{part.label}</span>
 	<span class="input-group">
 		<span class="currency-symbol">{currencySymbol}</span>
-		<input
-			type="number"
-			inputmode="decimal"
-			min="0"
-			step="0.01"
-			bind:value
-			oninput={handleInput}
-		/>
+		<input type="number" inputmode="decimal" min="0" step="0.01" bind:value oninput={handleInput} />
 	</span>
 </label>
 

--- a/src/lib/components/HoldingsRow.svelte
+++ b/src/lib/components/HoldingsRow.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
+	import { getCurrencyOption } from '$lib/currency';
 	import type { PortfolioPart } from '$lib/portfolio';
+	import { currencySelection } from '$lib/state/currency.svelte';
 	import { portfolioHoldings } from '$lib/state/holdings.svelte';
 
 	let { part }: { part: PortfolioPart } = $props();
@@ -9,6 +11,8 @@
 	// changes after mount - only the initial stored amount should seed the input.
 	let value = $state(untrack(() => portfolioHoldings.amountFor(part.key)) || undefined);
 
+	const currencySymbol = $derived(getCurrencyOption(currencySelection.id).symbol);
+
 	function handleInput() {
 		portfolioHoldings.setAmount(part.key, Number.isFinite(value) ? (value as number) : 0);
 	}
@@ -16,7 +20,17 @@
 
 <label class="row">
 	<span class="name">{part.label}</span>
-	<input type="number" inputmode="decimal" min="0" step="0.01" bind:value oninput={handleInput} />
+	<span class="input-group">
+		<span class="currency-symbol">{currencySymbol}</span>
+		<input
+			type="number"
+			inputmode="decimal"
+			min="0"
+			step="0.01"
+			bind:value
+			oninput={handleInput}
+		/>
+	</span>
 </label>
 
 <style>
@@ -32,9 +46,22 @@
 		color: #0f172a;
 	}
 
+	.input-group {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+	}
+
+	.currency-symbol {
+		position: absolute;
+		left: 0.5rem;
+		color: #64748b;
+		pointer-events: none;
+	}
+
 	input {
 		width: 8rem;
-		padding: 0.375rem 0.5rem;
+		padding: 0.375rem 0.5rem 0.375rem 1.5rem;
 		border: 1px solid #cbd5e1;
 		border-radius: 0.5rem;
 		font: inherit;

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import HoldingsRow from '$lib/components/HoldingsRow.svelte';
 	import PieChart from '$lib/components/PieChart.svelte';
+	import { formatCurrency } from '$lib/currency';
 	import { getTemplate } from '$lib/portfolio';
 	import { buyOnlyActions } from '$lib/rebalance';
+	import { currencySelection } from '$lib/state/currency.svelte';
 	import { portfolioHoldings } from '$lib/state/holdings.svelte';
 	import { templateSelection } from '$lib/state/portfolio-template.svelte';
 
@@ -51,7 +53,7 @@
 				{#if buyActions.length > 0}
 					<ul class="actions">
 						{#each buyActions as action (action.partKey)}
-							<li>Buy {action.amount.toFixed(2)} of {action.partLabel}</li>
+							<li>Buy {formatCurrency(action.amount, currencySelection.id)} of {action.partLabel}</li>
 						{/each}
 					</ul>
 					<button type="button" class="apply" onclick={applyBuyPlan}>Apply</button>

--- a/src/lib/components/TemplateSelector.svelte
+++ b/src/lib/components/TemplateSelector.svelte
@@ -1,12 +1,32 @@
 <script lang="ts">
 	import { PART_COLORS } from '$lib/colors';
+	import { CURRENCY_OPTIONS } from '$lib/currency';
 	import { PORTFOLIO_TEMPLATES } from '$lib/portfolio';
+	import { currencySelection } from '$lib/state/currency.svelte';
 	import { templateSelection } from '$lib/state/portfolio-template.svelte';
 </script>
 
 <div class="selector">
 	<h1>Choose your portfolio template</h1>
 	<p class="intro">Pick the target allocation you want to rebalance towards.</p>
+
+	<div class="currency-picker">
+		<span class="currency-label" id="currency-label">Currency</span>
+		<div class="currency-options" role="group" aria-labelledby="currency-label">
+			{#each CURRENCY_OPTIONS as option (option.id)}
+				{@const isSelected = currencySelection.id === option.id}
+				<button
+					type="button"
+					class="currency-option"
+					class:selected={isSelected}
+					aria-pressed={isSelected}
+					onclick={() => currencySelection.select(option.id)}
+				>
+					{option.symbol} {option.label}
+				</button>
+			{/each}
+		</div>
+	</div>
 
 	<ul class="templates">
 		{#each PORTFOLIO_TEMPLATES as template (template.id)}
@@ -55,6 +75,39 @@
 	.intro {
 		margin: 0 0 1.5rem;
 		color: #475569;
+	}
+
+	.currency-picker {
+		margin: 0 0 1.5rem;
+	}
+
+	.currency-label {
+		display: block;
+		font-size: 0.875rem;
+		font-weight: 600;
+		margin: 0 0 0.5rem;
+	}
+
+	.currency-options {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.currency-option {
+		flex: 1;
+		text-align: center;
+		background: #f8fafc;
+		border: 2px solid #e2e8f0;
+		border-radius: 0.75rem;
+		padding: 0.5rem;
+		cursor: pointer;
+		font: inherit;
+		color: inherit;
+	}
+
+	.currency-option.selected {
+		border-color: #0f172a;
+		background: #f1f5f9;
 	}
 
 	.templates {

--- a/src/lib/currency.test.ts
+++ b/src/lib/currency.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { formatCurrency } from './currency';
+
+describe('formatCurrency', () => {
+	it('formats EUR with a period thousands separator and comma decimal', () => {
+		const result = formatCurrency(1234.5, 'EUR');
+		expect(result).toContain('€');
+		expect(result).toContain('1.234,50');
+	});
+
+	it('formats USD with a comma thousands separator and period decimal', () => {
+		expect(formatCurrency(1234.5, 'USD')).toBe('$1,234.50');
+	});
+});

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,33 @@
+export type CurrencyId = 'EUR' | 'USD';
+
+export interface CurrencyOption {
+	id: CurrencyId;
+	label: string;
+	symbol: string;
+	locale: string;
+}
+
+export const CURRENCY_OPTIONS: CurrencyOption[] = [
+	{ id: 'EUR', label: 'Euro', symbol: '€', locale: 'de-DE' },
+	{ id: 'USD', label: 'US Dollar', symbol: '$', locale: 'en-US' }
+];
+
+export function getCurrencyOption(id: CurrencyId): CurrencyOption {
+	return CURRENCY_OPTIONS.find((option) => option.id === id) ?? CURRENCY_OPTIONS[0];
+}
+
+const formatters = new Map<CurrencyId, Intl.NumberFormat>();
+
+function formatterFor(currencyId: CurrencyId): Intl.NumberFormat {
+	let formatter = formatters.get(currencyId);
+	if (!formatter) {
+		const option = getCurrencyOption(currencyId);
+		formatter = new Intl.NumberFormat(option.locale, { style: 'currency', currency: option.id });
+		formatters.set(currencyId, formatter);
+	}
+	return formatter;
+}
+
+export function formatCurrency(amount: number, currencyId: CurrencyId): string {
+	return formatterFor(currencyId).format(amount);
+}

--- a/src/lib/state/currency.svelte.ts
+++ b/src/lib/state/currency.svelte.ts
@@ -1,0 +1,29 @@
+import { browser } from '$app/environment';
+import { CURRENCY_OPTIONS, type CurrencyId } from '$lib/currency';
+
+const STORAGE_KEY = 'stblzr:currency';
+const DEFAULT_CURRENCY: CurrencyId = 'EUR';
+
+function isCurrencyId(value: string): value is CurrencyId {
+	return CURRENCY_OPTIONS.some((option) => option.id === value);
+}
+
+function readStored(): CurrencyId {
+	if (!browser) return DEFAULT_CURRENCY;
+	const stored = localStorage.getItem(STORAGE_KEY);
+	return stored && isCurrencyId(stored) ? stored : DEFAULT_CURRENCY;
+}
+
+let selectedCurrency = $state<CurrencyId>(readStored());
+
+export const currencySelection = {
+	get id() {
+		return selectedCurrency;
+	},
+	select(id: CurrencyId) {
+		selectedCurrency = id;
+		if (browser) {
+			localStorage.setItem(STORAGE_KEY, id);
+		}
+	}
+};


### PR DESCRIPTION
## Summary
- Amounts are now displayed with a currency symbol and locale-correct separators (via `Intl.NumberFormat`) instead of plain numbers.
- The onboarding screen now lets you persistently choose Euro (default) or US Dollar, each with correct separators (European for EUR, American for USD).
- Closes #6.

## Test plan
- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] Manually verify onboarding currency picker and holdings/rebalance amounts in the browser

Generated with [Claude Code](https://claude.ai/code)