### PR TITLE
fix: correct Prettier formatting in PortfolioView and TemplateSelector

### DIFF
--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -53,7 +53,9 @@
 				{#if buyActions.length > 0}
 					<ul class="actions">
 						{#each buyActions as action (action.partKey)}
-							<li>Buy {formatCurrency(action.amount, currencySelection.id)} of {action.partLabel}</li>
+							<li>
+								Buy {formatCurrency(action.amount, currencySelection.id)} of {action.partLabel}
+							</li>
 						{/each}
 					</ul>
 					<button type="button" class="apply" onclick={applyBuyPlan}>Apply</button>
@@ -70,10 +72,7 @@
 		max-width: 28rem;
 		margin: 0 auto;
 		padding: calc(1.5rem + env(safe-area-inset-top)) 1rem 1.5rem;
-		font-family:
-			system-ui,
-			-apple-system,
-			sans-serif;
+		font-family: system-ui, -apple-system, sans-serif;
 		color: #0f172a;
 	}
 

--- a/src/lib/components/TemplateSelector.svelte
+++ b/src/lib/components/TemplateSelector.svelte
@@ -60,10 +60,7 @@
 		max-width: 28rem;
 		margin: 0 auto;
 		padding: calc(1.5rem + env(safe-area-inset-top)) 1rem 1.5rem;
-		font-family:
-			system-ui,
-			-apple-system,
-			sans-serif;
+		font-family: system-ui, -apple-system, sans-serif;
 		color: #0f172a;
 	}
 


### PR DESCRIPTION
Fixes #8.

Collapses the font-family list back onto one line (it fits within printWidth) and wraps the buy-plan list item text that exceeded printWidth: 100, both flagged by `npm run lint`. Formatting-only, no behavior change.

Generated with [Claude Code](https://claude.ai/code)