### PR TITLE
Add descriptions for portfolio templates

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -11,6 +11,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 - [x] **US-3**: As a returning user with a saved template, I skip onboarding and go straight to my portfolio view.
 - [ ] **US-13**: As a user, I can give each part of my split a name of my own choosing, saved persistently, so I still recognize what each allocation represents even after not checking my portfolio for a long time.
 - [x] **US-14**: As a user, I can choose my currency (Euro or US Dollar) on the onboarding screen, saved persistently, with Euro as the default, so my amounts are shown in the currency I actually use.
+- [x] **US-16**: As a user, I see a short description of each portfolio template on the selection screen explaining its rationale (e.g. why 50/30/20 splits allocations the way it does), so I can pick the template that matches my investing philosophy.
 
 ## Target allocation view
 

--- a/src/lib/components/TemplateSelector.svelte
+++ b/src/lib/components/TemplateSelector.svelte
@@ -41,6 +41,7 @@
 					onclick={() => templateSelection.select(template.id)}
 				>
 					<span class="label">{template.label}</span>
+					<span class="description">{template.description}</span>
 					<span class="bar" role="presentation">
 						{#each template.parts as part, i (part.key)}
 							<span
@@ -143,6 +144,11 @@
 	.label {
 		font-size: 1.125rem;
 		font-weight: 600;
+	}
+
+	.description {
+		font-size: 0.875rem;
+		color: #475569;
 	}
 
 	.bar {

--- a/src/lib/portfolio.test.ts
+++ b/src/lib/portfolio.test.ts
@@ -13,6 +13,12 @@ describe('PORTFOLIO_TEMPLATES', () => {
 		const ids = PORTFOLIO_TEMPLATES.map((template) => template.id);
 		expect(new Set(ids).size).toBe(ids.length);
 	});
+
+	it('has a non-empty description for every template', () => {
+		for (const template of PORTFOLIO_TEMPLATES) {
+			expect(template.description.length).toBeGreaterThan(0);
+		}
+	});
 });
 
 describe('getTemplate', () => {

--- a/src/lib/portfolio.ts
+++ b/src/lib/portfolio.ts
@@ -7,6 +7,7 @@ export interface PortfolioPart {
 export interface PortfolioTemplate {
 	id: string;
 	label: string;
+	description: string;
 	parts: PortfolioPart[];
 }
 
@@ -14,6 +15,8 @@ export const PORTFOLIO_TEMPLATES: PortfolioTemplate[] = [
 	{
 		id: '50-30-20',
 		label: '50/30/20',
+		description:
+			'Weights regions roughly by their share of global economic output (GDP): World, Emerging Markets, and Europe.',
 		parts: [
 			{ key: 'world', label: 'World', targetPct: 50 },
 			{ key: 'emerging-markets', label: 'Emerging Markets', targetPct: 30 },
@@ -23,6 +26,8 @@ export const PORTFOLIO_TEMPLATES: PortfolioTemplate[] = [
 	{
 		id: '70-30',
 		label: '70/30',
+		description:
+			'A simpler split favoring World over Emerging Markets, without a separate Europe allocation.',
 		parts: [
 			{ key: 'world', label: 'World', targetPct: 70 },
 			{ key: 'emerging-markets', label: 'Emerging Markets', targetPct: 30 }

--- a/src/lib/rebalance.test.ts
+++ b/src/lib/rebalance.test.ts
@@ -5,6 +5,8 @@ import type { PortfolioTemplate } from './portfolio';
 const template: PortfolioTemplate = {
 	id: '70-30',
 	label: '70/30',
+	description:
+		'A simpler split favoring World over Emerging Markets, without a separate Europe allocation.',
 	parts: [
 		{ key: 'world', label: 'World', targetPct: 70 },
 		{ key: 'emerging-markets', label: 'Emerging Markets', targetPct: 30 }


### PR DESCRIPTION
## Summary

Adds a short description to each portfolio template (50/30/20, 70/30), shown on the template selection screen, explaining the rationale behind the split (e.g. that 50/30/20 weights regions by GDP share).

Closes #11.

## Changes
- Added `description` field to `PortfolioTemplate` in `src/lib/portfolio.ts`
- Rendered the description on the selection screen in `TemplateSelector.svelte`
- Added test coverage and logged **US-16** in `USER_STORIES.md`

Generated with [Claude Code](https://claude.ai/code)