### PR TITLE
Fix iOS keyboard hiding the top bar and blocking pie-to-bar-chart transition

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,10 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
+		/>
 		<meta name="text-scale" content="scale" />
 		<meta name="theme-color" content="#0f172a" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary
- iOS Safari doesn't resize the layout viewport when the on-screen keyboard opens by default, so it scrolls the whole page to reveal the focused input instead — pushing the fixed header out of view, and leaving `dvh`/media queries unchanged so the pie-to-bar-chart transition in `PortfolioView.svelte` never triggers.
- Added `interactive-widget=resizes-content` to the viewport `<meta>` tag in `src/app.html` so the browser actually shrinks the content viewport on keyboard open, matching what the existing CSS was already written to expect.

Closes #13.

Generated with [Claude Code](https://claude.ai/code)