### PR TITLE
Fix keyboard-avoidance layout and Safari number-input ellipsis

### DIFF
--- a/src/lib/components/AppScreen.svelte
+++ b/src/lib/components/AppScreen.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import AppHeader from '$lib/components/AppHeader.svelte';
+	import { viewportSize } from '$lib/state/viewport.svelte';
 	import type { Snippet } from 'svelte';
 
 	let { title, subtitle, children }: { title: string; subtitle?: string; children: Snippet } =
 		$props();
 </script>
 
-<div class="screen">
+<div class="screen" style:height="{viewportSize.height}px">
 	<AppHeader {title} {subtitle} />
 	<div class="scroll-area">
 		{@render children()}

--- a/src/lib/components/HoldingsRow.svelte
+++ b/src/lib/components/HoldingsRow.svelte
@@ -60,6 +60,7 @@
 		font: inherit;
 		text-align: right;
 		appearance: textfield;
+		-webkit-appearance: textfield;
 		-moz-appearance: textfield;
 	}
 

--- a/src/lib/components/PieChart.svelte
+++ b/src/lib/components/PieChart.svelte
@@ -2,6 +2,7 @@
 	import { PART_COLORS } from '$lib/colors';
 	import { computeAnnularSlices } from '$lib/pie';
 	import type { PortfolioPart } from '$lib/portfolio';
+	import { viewportSize } from '$lib/state/viewport.svelte';
 
 	let {
 		parts,
@@ -44,9 +45,17 @@
 				})
 			: []
 	);
+
+	// Vertical space gets tight when the on-screen keyboard opens on a phone. Squash the
+	// circle into an ellipse first to save height, then drop to horizontal bars once an
+	// ellipse would end up too flat to read. Driven by the live visual-viewport height
+	// (not a `@media (max-height)` query) since Safari never shrinks the CSS viewport
+	// for the keyboard.
+	const squashed = $derived(viewportSize.height <= 700);
+	const barsOnly = $derived(viewportSize.height <= 480);
 </script>
 
-<div class="chart">
+<div class="chart" class:squashed style:display={barsOnly ? 'none' : undefined}>
 	<svg
 		viewBox="0 0 112 112"
 		preserveAspectRatio="none"
@@ -66,7 +75,12 @@
 	{/if}
 </div>
 
-<div class="bars" role="img" aria-label="Portfolio allocation">
+<div
+	class="bars"
+	style:display={barsOnly ? 'flex' : undefined}
+	role="img"
+	aria-label="Portfolio allocation"
+>
 	<span class="bar target-bar" role="presentation">
 		{#each parts as part, i (part.key)}
 			<span
@@ -150,22 +164,7 @@
 		color: #64748b;
 	}
 
-	/* Vertical space gets tight when the on-screen keyboard opens on a phone.
-	   Squash the circle into an ellipse first to save height, then drop to
-	   horizontal bars once an ellipse would end up too flat to read. */
-	@media (max-height: 700px) {
-		.chart {
-			aspect-ratio: 2.6 / 1;
-		}
-	}
-
-	@media (max-height: 480px) {
-		.chart {
-			display: none;
-		}
-
-		.bars {
-			display: flex;
-		}
+	.chart.squashed {
+		aspect-ratio: 2.6 / 1;
 	}
 </style>

--- a/src/lib/state/viewport.svelte.ts
+++ b/src/lib/state/viewport.svelte.ts
@@ -1,0 +1,32 @@
+import { browser } from '$app/environment';
+
+// iOS Safari never shrinks the CSS/layout viewport for the on-screen keyboard - there's
+// no browser chrome to hide, so `dvh` and `@media (max-height)` stay static even in a
+// plain browser tab, and *especially* in standalone/PWA mode. Instead it pans the
+// *visual* viewport, which only the VisualViewport API can observe. Tracking it here
+// gives every component a reliable "how much space is actually visible right now".
+function readHeight(): number {
+	if (!browser) return 0;
+	return window.visualViewport?.height ?? window.innerHeight;
+}
+
+let height = $state(readHeight());
+
+if (browser) {
+	const sync = () => {
+		height = readHeight();
+		// iOS also tries to scroll the page to "reveal" the focused input instead of
+		// just shrinking the visible area - keep it pinned since our layout already
+		// accounts for the smaller height.
+		window.scrollTo(0, 0);
+	};
+	window.visualViewport?.addEventListener('resize', sync);
+	window.visualViewport?.addEventListener('scroll', sync);
+	window.addEventListener('resize', sync);
+}
+
+export const viewportSize = {
+	get height() {
+		return height;
+	}
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,5 +13,8 @@
 <style>
 	:global(html, body) {
 		margin: 0;
+		height: 100%;
+		overflow: hidden;
+		overscroll-behavior: none;
 	}
 </style>


### PR DESCRIPTION
Fixes #15 — the previous fix for #13 relied on `100dvh` and a Chrome-only `interactive-widget` meta hint, neither of which affects Safari/WebKit (in a tab or standalone/PWA mode). This switches to tracking the real visible height via the VisualViewport API, pins html/body so iOS can't scroll the header out of view, and fixes the Safari number-input ellipsis bug with `-webkit-appearance: textfield`.

**Note:** could not run lint/type-check/tests in this sandbox (no permission to run npm) — please verify locally, especially on an actual iOS device in standalone PWA mode.

Generated with [Claude Code](https://claude.ai/code)