### PR TITLE
Remove dynamic ellipse pie chart behavior

### DIFF
--- a/src/lib/components/PieChart.svelte
+++ b/src/lib/components/PieChart.svelte
@@ -54,12 +54,7 @@
 </script>
 
 <div class="chart" style:display={barsOnly ? 'none' : undefined}>
-	<svg
-		viewBox="0 0 112 112"
-		class="pie"
-		role="img"
-		aria-label="Portfolio allocation"
-	>
+	<svg viewBox="0 0 112 112" class="pie" role="img" aria-label="Portfolio allocation">
 		{#each targetSlices as slice, i (slice.key)}
 			<path d={slice.path} fill={PART_COLORS[i % PART_COLORS.length]} />
 		{/each}

--- a/src/lib/components/PieChart.svelte
+++ b/src/lib/components/PieChart.svelte
@@ -46,19 +46,16 @@
 			: []
 	);
 
-	// Vertical space gets tight when the on-screen keyboard opens on a phone. Squash the
-	// circle into an ellipse first to save height, then drop to horizontal bars once an
-	// ellipse would end up too flat to read. Driven by the live visual-viewport height
-	// (not a `@media (max-height)` query) since Safari never shrinks the CSS viewport
-	// for the keyboard.
-	const squashed = $derived(viewportSize.height <= 700);
+	// Vertical space gets tight when the on-screen keyboard opens on a phone. Drop to
+	// horizontal bars once there's too little height for the pie chart. Driven by the
+	// live visual-viewport height (not a `@media (max-height)` query) since Safari never
+	// shrinks the CSS viewport for the keyboard.
 	const barsOnly = $derived(viewportSize.height <= 480);
 </script>
 
-<div class="chart" class:squashed style:display={barsOnly ? 'none' : undefined}>
+<div class="chart" style:display={barsOnly ? 'none' : undefined}>
 	<svg
 		viewBox="0 0 112 112"
-		preserveAspectRatio="none"
 		class="pie"
 		role="img"
 		aria-label="Portfolio allocation"
@@ -162,9 +159,5 @@
 		margin: 0;
 		font-size: 0.75rem;
 		color: #64748b;
-	}
-
-	.chart.squashed {
-		aspect-ratio: 2.6 / 1;
 	}
 </style>


### PR DESCRIPTION
Removes the pie chart's dynamic ellipse-squash behavior (it used to flatten into an ellipse as the viewport shrank before dropping to the bar chart). The pie now stays circular and switches directly to the bar chart once space is tight, keeping both chart types.

Fixes #17.

Generated with [Claude Code](https://claude.ai/code)