### PR TITLE
fix: stop controls jumping when switching input fields on iOS

### DIFF
--- a/src/lib/state/viewport.svelte.ts
+++ b/src/lib/state/viewport.svelte.ts
@@ -13,12 +13,23 @@ function readHeight(): number {
 let height = $state(readHeight());
 
 if (browser) {
+	// Moving focus from one input to another makes iOS briefly report the keyboard as
+	// closing (old field blurs) and then reopening (new field focuses), firing extra
+	// resize/scroll events with a transient, momentarily-taller height in between. Applying
+	// every event as it arrives made the layout visibly jump for that brief moment, so the
+	// height is only committed once events stop arriving for a short debounce window -
+	// short enough to still feel instant for a real keyboard open/close, long enough to
+	// swallow the in-between blip from switching fields.
+	let debounce: ReturnType<typeof setTimeout> | undefined;
 	const sync = () => {
-		height = readHeight();
-		// iOS also tries to scroll the page to "reveal" the focused input instead of
-		// just shrinking the visible area - keep it pinned since our layout already
-		// accounts for the smaller height.
-		window.scrollTo(0, 0);
+		clearTimeout(debounce);
+		debounce = setTimeout(() => {
+			height = readHeight();
+			// iOS also tries to scroll the page to "reveal" the focused input instead of
+			// just shrinking the visible area - keep it pinned since our layout already
+			// accounts for the smaller height.
+			window.scrollTo(0, 0);
+		}, 100);
 	};
 	window.visualViewport?.addEventListener('resize', sync);
 	window.visualViewport?.addEventListener('scroll', sync);


### PR DESCRIPTION
Fixes #19.

When switching focus between holdings input fields with the iOS keyboard open, iOS briefly reports the keyboard as closing (blur) and then reopening (focus), firing extra `visualViewport` resize/scroll events with a transient, momentarily taller height in between. The app applied every such event immediately, causing the layout to visibly jump.

This debounces the height/scroll pin in `src/lib/state/viewport.svelte.ts` by 100ms so only the settled post-transition value is applied.

Generated with [Claude Code](https://claude.ai/code)