### PR TITLE
fix: pin scroll immediately instead of debounced (#21)

### DIFF
--- a/src/lib/state/viewport.svelte.ts
+++ b/src/lib/state/viewport.svelte.ts
@@ -13,22 +13,28 @@ function readHeight(): number {
 let height = $state(readHeight());
 
 if (browser) {
+	// iOS also tries to scroll the page to "reveal" the focused input instead of just
+	// shrinking the visible area. That scroll happens immediately as focus moves, so it
+	// has to be undone on every single event, not just once things settle down - a
+	// debounced correction still lets the native scroll flash on screen for however long
+	// the debounce window is, no matter how short it's set.
+	const pinScroll = () => window.scrollTo(0, 0);
+	window.visualViewport?.addEventListener('resize', pinScroll);
+	window.visualViewport?.addEventListener('scroll', pinScroll);
+	window.addEventListener('scroll', pinScroll);
+
 	// Moving focus from one input to another makes iOS briefly report the keyboard as
 	// closing (old field blurs) and then reopening (new field focuses), firing extra
-	// resize/scroll events with a transient, momentarily-taller height in between. Applying
-	// every event as it arrives made the layout visibly jump for that brief moment, so the
-	// height is only committed once events stop arriving for a short debounce window -
-	// short enough to still feel instant for a real keyboard open/close, long enough to
-	// swallow the in-between blip from switching fields.
+	// resize events with a transient, momentarily-taller height in between. Applying every
+	// event as it arrives made the layout visibly jump for that brief moment, so the height
+	// is only committed once events stop arriving for a short debounce window - short
+	// enough to still feel instant for a real keyboard open/close, long enough to swallow
+	// the in-between blip from switching fields.
 	let debounce: ReturnType<typeof setTimeout> | undefined;
 	const sync = () => {
 		clearTimeout(debounce);
 		debounce = setTimeout(() => {
 			height = readHeight();
-			// iOS also tries to scroll the page to "reveal" the focused input instead of
-			// just shrinking the visible area - keep it pinned since our layout already
-			// accounts for the smaller height.
-			window.scrollTo(0, 0);
 		}, 100);
 	};
 	window.visualViewport?.addEventListener('resize', sync);


### PR DESCRIPTION
## Summary
- Fixes remaining scroll jumping from #19: the scroll correction was only applied inside the debounced height-commit callback, so iOS's native "scroll focused input into view" was still visible for up to 100ms after switching fields.
- `window.scrollTo(0, 0)` now runs synchronously on every scroll/resize event, decoupled from the debounced height update.

Closes #21, related to #19.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run check`
- [ ] `npm run test`
- [ ] Manually verify on iOS Safari: tap between input fields and confirm no visible scroll jump

Generated with [Claude Code](https://claude.ai/code)