### PR TITLE
Add sell-and-rebuy minimal rebalancing option

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -27,9 +27,9 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 ## Rebalancing
 
 - [x] **US-8**: As a user, I can see a "buy-only" rebalancing option: how much additional currency to put into each under-weight part, without selling anything.
-- [ ] **US-9**: As a user, I can see a "sell-and-rebuy minimal" rebalancing option: the smallest set of sells and buys needed to hit my target allocation exactly.
-- [~] **US-10**: As a user, for each rebalancing option (buy-only or sell-and-rebuy minimal), I get a detailed list of actions to take, each with the ETF/stock and the currency amount to buy or sell. (Buy-only's list is always visible; sell-and-rebuy isn't built yet, see US-9.)
-- [ ] **US-11**: As a user, I see a small warning indicator next to the "sell-and-rebuy minimal" option noting that selling may trigger taxes, so I'm not caught off guard before choosing it.
+- [x] **US-9**: As a user, I can see a "sell-and-rebuy minimal" rebalancing option: the smallest set of sells and buys needed to hit my target allocation exactly.
+- [x] **US-10**: As a user, for each rebalancing option (buy-only or sell-and-rebuy minimal), I get a detailed list of actions to take, each with the ETF/stock and the currency amount to buy or sell.
+- [x] **US-11**: As a user, I see a small warning indicator next to the "sell-and-rebuy minimal" option noting that selling may trigger taxes, so I'm not caught off guard before choosing it.
 - [x] **US-12**: As a user, after confirming the rebalancing option I picked, the pie chart updates to reflect the new balanced state and shows the new per-part amounts, and these updated holdings are saved persistently so they're there next time I open the app.
 
 ## Backlog / not yet scoped

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -4,23 +4,27 @@
 	import PieChart from '$lib/components/PieChart.svelte';
 	import { formatCurrency } from '$lib/currency';
 	import { getTemplate } from '$lib/portfolio';
-	import { buyOnlyActions } from '$lib/rebalance';
+	import { buyOnlyActions, sellAndRebuyMinimalActions } from '$lib/rebalance';
 	import { currencySelection } from '$lib/state/currency.svelte';
 	import { portfolioHoldings } from '$lib/state/holdings.svelte';
 	import { templateSelection } from '$lib/state/portfolio-template.svelte';
 
 	const template = $derived(templateSelection.id ? getTemplate(templateSelection.id) : undefined);
 	const buyActions = $derived(template ? buyOnlyActions(template, portfolioHoldings.all) : []);
+	const sellAndRebuyActions = $derived(
+		template ? sellAndRebuyMinimalActions(template, portfolioHoldings.all) : []
+	);
 
 	// Bumped after applying a plan so the (locally-buffered) HoldingsRow inputs remount
 	// and pick up the new stored amounts instead of showing stale, pre-apply values.
 	let holdingsVersion = $state(0);
 
-	function applyBuyPlan() {
-		for (const action of buyActions) {
+	function applyPlan(actions: { partKey: string; type: 'buy' | 'sell'; amount: number }[]) {
+		for (const action of actions) {
+			const current = portfolioHoldings.amountFor(action.partKey);
 			portfolioHoldings.setAmount(
 				action.partKey,
-				portfolioHoldings.amountFor(action.partKey) + action.amount
+				action.type === 'buy' ? current + action.amount : current - action.amount
 			);
 		}
 		holdingsVersion += 1;
@@ -53,9 +57,28 @@
 							</li>
 						{/each}
 					</ul>
-					<button type="button" class="apply" onclick={applyBuyPlan}>Apply</button>
+					<button type="button" class="apply" onclick={() => applyPlan(buyActions)}>Apply</button>
 				{:else}
 					<p class="balanced">Already balanced — nothing to buy.</p>
+				{/if}
+
+				<h3>Sell and rebuy (minimal)</h3>
+				<p class="warning">⚠️ Selling may trigger taxes and other costs.</p>
+
+				{#if sellAndRebuyActions.length > 0}
+					<ul class="actions">
+						{#each sellAndRebuyActions as action (action.partKey)}
+							<li>
+								{action.type === 'buy' ? 'Buy' : 'Sell'}
+								{formatCurrency(action.amount, currencySelection.id)} of {action.partLabel}
+							</li>
+						{/each}
+					</ul>
+					<button type="button" class="apply" onclick={() => applyPlan(sellAndRebuyActions)}>
+						Apply
+					</button>
+				{:else}
+					<p class="balanced">Already balanced — nothing to sell or buy.</p>
 				{/if}
 			</section>
 		{/if}
@@ -84,6 +107,17 @@
 		font-weight: 600;
 		color: #475569;
 		margin: 0 0 0.5rem;
+	}
+
+	.actions + h3,
+	.balanced + h3 {
+		margin-top: 1.5rem;
+	}
+
+	.warning {
+		margin: 0 0 0.5rem;
+		font-size: 0.8125rem;
+		color: #b45309;
 	}
 
 	button {

--- a/src/lib/rebalance.test.ts
+++ b/src/lib/rebalance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buyOnlyActions } from './rebalance';
+import { buyOnlyActions, sellAndRebuyMinimalActions } from './rebalance';
 import type { PortfolioTemplate } from './portfolio';
 
 const template: PortfolioTemplate = {
@@ -39,6 +39,49 @@ describe('buyOnlyActions', () => {
 
 		expect(actions).toEqual([
 			{ partKey: 'emerging-markets', partLabel: 'Emerging Markets', type: 'buy', amount: 300 }
+		]);
+	});
+});
+
+describe('sellAndRebuyMinimalActions', () => {
+	it('sells exactly the over-weight excess and buys exactly the under-weight shortfall', () => {
+		const actions = sellAndRebuyMinimalActions(template, { world: 800, 'emerging-markets': 200 });
+
+		expect(actions).toEqual([
+			{ partKey: 'world', partLabel: 'World', type: 'sell', amount: 100 },
+			{ partKey: 'emerging-markets', partLabel: 'Emerging Markets', type: 'buy', amount: 100 }
+		]);
+	});
+
+	it('keeps the portfolio total unchanged, unlike buy-only', () => {
+		const holdings = { world: 800, 'emerging-markets': 200 };
+		const actions = sellAndRebuyMinimalActions(template, holdings);
+
+		const net = actions.reduce(
+			(sum, action) => sum + (action.type === 'buy' ? action.amount : -action.amount),
+			0
+		);
+		expect(net).toBe(0);
+	});
+
+	it('returns no actions for an already-balanced portfolio', () => {
+		const actions = sellAndRebuyMinimalActions(template, { world: 700, 'emerging-markets': 300 });
+
+		expect(actions).toEqual([]);
+	});
+
+	it('returns no actions when nothing has been entered yet', () => {
+		const actions = sellAndRebuyMinimalActions(template, {});
+
+		expect(actions).toEqual([]);
+	});
+
+	it('treats a missing part as zero holdings', () => {
+		const actions = sellAndRebuyMinimalActions(template, { world: 700 });
+
+		expect(actions).toEqual([
+			{ partKey: 'world', partLabel: 'World', type: 'sell', amount: 210 },
+			{ partKey: 'emerging-markets', partLabel: 'Emerging Markets', type: 'buy', amount: 210 }
 		]);
 	});
 });

--- a/src/lib/rebalance.ts
+++ b/src/lib/rebalance.ts
@@ -42,3 +42,33 @@ export function buyOnlyActions(
 		})
 		.filter((action) => action.amount > 0);
 }
+
+/**
+ * Sell-and-rebuy minimal rebalancing: hit the target allocation exactly, without
+ * adding any new money, by moving value from over-weight parts into under-weight
+ * ones. The portfolio total stays fixed at the current sum of holdings, so each
+ * part's target amount is `total * targetPct`. Selling exactly the over-weight
+ * excess (and buying exactly the under-weight shortfall) is the smallest possible
+ * set of trades that reaches target - any smaller sell would leave some part off
+ * target.
+ */
+export function sellAndRebuyMinimalActions(
+	template: PortfolioTemplate,
+	holdings: Record<string, number>
+): RebalanceAction[] {
+	const total = template.parts.reduce((sum, part) => sum + (holdings[part.key] ?? 0), 0);
+
+	return template.parts
+		.map((part) => {
+			const current = holdings[part.key] ?? 0;
+			const targetAmount = (part.targetPct / 100) * total;
+			const diff = roundCurrency(targetAmount - current);
+			return {
+				partKey: part.key,
+				partLabel: part.label,
+				type: diff >= 0 ? ('buy' as const) : ('sell' as const),
+				amount: Math.abs(diff)
+			};
+		})
+		.filter((action) => action.amount > 0);
+}


### PR DESCRIPTION
Adds a "sell and rebuy (minimal)" rebalancing option next to "buy only", covering the case where not enough cash is available to buy immediately. The amounts are optimized to sell as little as possible, and a warning notes that selling may trigger taxes and other costs.

Closes #23.

Generated with [Claude Code](https://claude.ai/code)