### PR TITLE
Unify buy-only / sell-and-rebuy rebalancing options

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -31,6 +31,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 - [x] **US-10**: As a user, for each rebalancing option (buy-only or sell-and-rebuy minimal), I get a detailed list of actions to take, each with the ETF/stock and the currency amount to buy or sell.
 - [x] **US-11**: As a user, I see a small warning indicator next to the "sell-and-rebuy minimal" option noting that selling may trigger taxes, so I'm not caught off guard before choosing it.
 - [x] **US-12**: As a user, after confirming the rebalancing option I picked, the pie chart updates to reflect the new balanced state and shows the new per-part amounts, and these updated holdings are saved persistently so they're there next time I open the app.
+- [x] **US-16**: As a user, I pick one rebalancing option at a time via side-by-side buttons and act on it with a single Apply button, rather than seeing both options with their own Apply buttons at once; within the sell-and-rebuy plan, sells are listed above buys.
 
 ## Backlog / not yet scoped
 

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -11,8 +11,21 @@
 
 	const template = $derived(templateSelection.id ? getTemplate(templateSelection.id) : undefined);
 	const buyActions = $derived(template ? buyOnlyActions(template, portfolioHoldings.all) : []);
+	// Sells listed above buys within the sell-and-rebuy plan.
 	const sellAndRebuyActions = $derived(
-		template ? sellAndRebuyMinimalActions(template, portfolioHoldings.all) : []
+		template
+			? [...sellAndRebuyMinimalActions(template, portfolioHoldings.all)].sort((a, b) =>
+					a.type === b.type ? 0 : a.type === 'sell' ? -1 : 1
+				)
+			: []
+	);
+
+	let selectedOption = $state<'buy' | 'sellRebuy'>('buy');
+	const activeActions = $derived(selectedOption === 'buy' ? buyActions : sellAndRebuyActions);
+	const activePlanLabel = $derived(
+		selectedOption === 'buy'
+			? 'Already balanced — nothing to buy.'
+			: 'Already balanced — nothing to sell or buy.'
 	);
 
 	// Bumped after applying a plan so the (locally-buffered) HoldingsRow inputs remount
@@ -47,38 +60,44 @@
 
 			<section>
 				<h2>Rebalance</h2>
-				<h3>Buy only</h3>
 
-				{#if buyActions.length > 0}
-					<ul class="actions">
-						{#each buyActions as action (action.partKey)}
-							<li>
-								Buy {formatCurrency(action.amount, currencySelection.id)} of {action.partLabel}
-							</li>
-						{/each}
-					</ul>
-					<button type="button" class="apply" onclick={() => applyPlan(buyActions)}>Apply</button>
-				{:else}
-					<p class="balanced">Already balanced — nothing to buy.</p>
+				<div class="option-tabs" role="group" aria-label="Rebalancing option">
+					<button
+						type="button"
+						class="tab"
+						class:active={selectedOption === 'buy'}
+						aria-pressed={selectedOption === 'buy'}
+						onclick={() => (selectedOption = 'buy')}
+					>
+						Buy only
+					</button>
+					<button
+						type="button"
+						class="tab"
+						class:active={selectedOption === 'sellRebuy'}
+						aria-pressed={selectedOption === 'sellRebuy'}
+						onclick={() => (selectedOption = 'sellRebuy')}
+					>
+						Sell and rebuy (minimal)
+					</button>
+				</div>
+
+				{#if selectedOption === 'sellRebuy'}
+					<p class="warning">⚠️ Selling may trigger taxes and other costs.</p>
 				{/if}
 
-				<h3>Sell and rebuy (minimal)</h3>
-				<p class="warning">⚠️ Selling may trigger taxes and other costs.</p>
-
-				{#if sellAndRebuyActions.length > 0}
+				{#if activeActions.length > 0}
 					<ul class="actions">
-						{#each sellAndRebuyActions as action (action.partKey)}
+						{#each activeActions as action (action.partKey)}
 							<li>
 								{action.type === 'buy' ? 'Buy' : 'Sell'}
 								{formatCurrency(action.amount, currencySelection.id)} of {action.partLabel}
 							</li>
 						{/each}
 					</ul>
-					<button type="button" class="apply" onclick={() => applyPlan(sellAndRebuyActions)}>
-						Apply
-					</button>
+					<button type="button" class="apply" onclick={() => applyPlan(activeActions)}>Apply</button>
 				{:else}
-					<p class="balanced">Already balanced — nothing to sell or buy.</p>
+					<p class="balanced">{activePlanLabel}</p>
 				{/if}
 			</section>
 		{/if}
@@ -102,20 +121,8 @@
 		margin: 1.5rem 0 0.5rem;
 	}
 
-	h3 {
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: #475569;
-		margin: 0 0 0.5rem;
-	}
-
-	.actions + h3,
-	.balanced + h3 {
-		margin-top: 1.5rem;
-	}
-
 	.warning {
-		margin: 0 0 0.5rem;
+		margin: 0.75rem 0 0.5rem;
 		font-size: 0.8125rem;
 		color: #b45309;
 	}
@@ -128,6 +135,22 @@
 		padding: 0.5rem 1rem;
 		font: inherit;
 		cursor: pointer;
+	}
+
+	.option-tabs {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.tab {
+		flex: 1;
+		background: #e2e8f0;
+		color: #334155;
+	}
+
+	.tab.active {
+		background: #0f172a;
+		color: #f8fafc;
 	}
 
 	.actions {

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -95,7 +95,9 @@
 							</li>
 						{/each}
 					</ul>
-					<button type="button" class="apply" onclick={() => applyPlan(activeActions)}>Apply</button>
+					<button type="button" class="apply" onclick={() => applyPlan(activeActions)}>
+						Apply
+					</button>
 				{:else}
 					<p class="balanced">{activePlanLabel}</p>
 				{/if}


### PR DESCRIPTION
## Summary
- Replaced the two always-visible rebalancing sections with side-by-side toggle buttons to select either "Buy only" or "Sell and rebuy (minimal)".
- A single Apply button now acts on whichever plan is selected.
- Within the sell-and-rebuy plan, sell actions are listed above buy actions.

Closes #26.

Generated with [Claude Code](https://claude.ai/code)