### PR TITLE
Never show cent values; round buy/sell amounts up

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -20,7 +20,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 ## Current holdings input
 
 - [x] **US-5**: As a user, I can enter the current currency amount I hold in each ETF/stock of my portfolio.
-- [x] **US-15**: As a user, all currency amounts I see are shown with the correct currency symbol and locale-appropriate separators (e.g. `1.234,56 €` for Euro, `$1,234.56` for US Dollar) based on my chosen currency.
+- [x] **US-15**: As a user, all currency amounts I see are shown with the correct currency symbol and locale-appropriate separators (e.g. `1.234 €` for Euro, `$1,234` for US Dollar) based on my chosen currency, and never with cent values.
 - [x] **US-6**: As a user, my entered holdings are saved persistently so I don't have to re-enter them every visit.
 - [x] **US-7**: As a user, once I've entered my holdings, I see an overlay on the pie chart with colored indicators showing which parts of my portfolio are over-weight and which are under-weight relative to target.
 
@@ -32,6 +32,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 - [x] **US-11**: As a user, I see a small warning indicator next to the "sell-and-rebuy minimal" option noting that selling may trigger taxes, so I'm not caught off guard before choosing it.
 - [x] **US-12**: As a user, after confirming the rebalancing option I picked, the pie chart updates to reflect the new balanced state and shows the new per-part amounts, and these updated holdings are saved persistently so they're there next time I open the app.
 - [x] **US-16**: As a user, I pick one rebalancing option at a time via side-by-side buttons and act on it with a single Apply button, rather than seeing both options with their own Apply buttons at once; within the sell-and-rebuy plan, sells are listed above buys.
+- [x] **US-17**: As a user, buy and sell amounts in a rebalancing plan are always whole currency units - if the exact target math would need cents, the amount is rounded up so applying the plan never leaves me short of target.
 
 ## Backlog / not yet scoped
 

--- a/src/lib/currency.test.ts
+++ b/src/lib/currency.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { formatCurrency } from './currency';
 
 describe('formatCurrency', () => {
-	it('formats EUR with a period thousands separator and comma decimal', () => {
-		const result = formatCurrency(1234.5, 'EUR');
+	it('formats EUR with a period thousands separator and no cents', () => {
+		const result = formatCurrency(1234, 'EUR');
 		expect(result).toContain('€');
-		expect(result).toContain('1.234,50');
+		expect(result).toContain('1.234');
+		expect(result).not.toContain(',');
 	});
 
-	it('formats USD with a comma thousands separator and period decimal', () => {
-		expect(formatCurrency(1234.5, 'USD')).toBe('$1,234.50');
+	it('formats USD with a comma thousands separator and no cents', () => {
+		expect(formatCurrency(1234, 'USD')).toBe('$1,234');
+	});
+
+	it('never shows cent values, even for fractional input', () => {
+		expect(formatCurrency(1234.5, 'USD')).not.toContain('.5');
+		expect(formatCurrency(1234.5, 'USD')).not.toMatch(/\.\d/);
 	});
 });

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -22,7 +22,12 @@ function formatterFor(currencyId: CurrencyId): Intl.NumberFormat {
 	let formatter = formatters.get(currencyId);
 	if (!formatter) {
 		const option = getCurrencyOption(currencyId);
-		formatter = new Intl.NumberFormat(option.locale, { style: 'currency', currency: option.id });
+		formatter = new Intl.NumberFormat(option.locale, {
+			style: 'currency',
+			currency: option.id,
+			minimumFractionDigits: 0,
+			maximumFractionDigits: 0
+		});
 		formatters.set(currencyId, formatter);
 	}
 	return formatter;

--- a/src/lib/rebalance.test.ts
+++ b/src/lib/rebalance.test.ts
@@ -41,6 +41,14 @@ describe('buyOnlyActions', () => {
 			{ partKey: 'emerging-markets', partLabel: 'Emerging Markets', type: 'buy', amount: 300 }
 		]);
 	});
+
+	it('rounds a fractional buy amount up to the next whole currency unit', () => {
+		const actions = buyOnlyActions(template, { world: 1, 'emerging-markets': 0 });
+
+		expect(actions).toEqual([
+			{ partKey: 'emerging-markets', partLabel: 'Emerging Markets', type: 'buy', amount: 1 }
+		]);
+	});
 });
 
 describe('sellAndRebuyMinimalActions', () => {
@@ -82,6 +90,15 @@ describe('sellAndRebuyMinimalActions', () => {
 		expect(actions).toEqual([
 			{ partKey: 'world', partLabel: 'World', type: 'sell', amount: 210 },
 			{ partKey: 'emerging-markets', partLabel: 'Emerging Markets', type: 'buy', amount: 210 }
+		]);
+	});
+
+	it('rounds fractional sell and buy amounts up to the next whole currency unit', () => {
+		const actions = sellAndRebuyMinimalActions(template, { world: 1, 'emerging-markets': 0 });
+
+		expect(actions).toEqual([
+			{ partKey: 'world', partLabel: 'World', type: 'sell', amount: 1 },
+			{ partKey: 'emerging-markets', partLabel: 'Emerging Markets', type: 'buy', amount: 1 }
 		]);
 	});
 });

--- a/src/lib/rebalance.ts
+++ b/src/lib/rebalance.ts
@@ -7,8 +7,13 @@ export interface RebalanceAction {
 	amount: number;
 }
 
-function roundCurrency(value: number): number {
-	return Math.round(value * 100) / 100;
+// Amounts are never shown with cents, so any calculated buy/sell amount is
+// rounded up to the next whole currency unit - rounding down would leave the
+// portfolio slightly off target after applying the plan. `value` is first
+// rounded to cent precision to absorb floating-point noise (e.g. 199.99999999997)
+// before the ceiling is applied, so noise never pushes a whole number up by one.
+function roundUpToWholeCurrency(value: number): number {
+	return Math.ceil(Math.round(value * 100) / 100);
 }
 
 /**
@@ -37,7 +42,7 @@ export function buyOnlyActions(
 				partKey: part.key,
 				partLabel: part.label,
 				type: 'buy' as const,
-				amount: Math.max(0, roundCurrency(targetAmount - current))
+				amount: Math.max(0, roundUpToWholeCurrency(targetAmount - current))
 			};
 		})
 		.filter((action) => action.amount > 0);
@@ -62,12 +67,12 @@ export function sellAndRebuyMinimalActions(
 		.map((part) => {
 			const current = holdings[part.key] ?? 0;
 			const targetAmount = (part.targetPct / 100) * total;
-			const diff = roundCurrency(targetAmount - current);
+			const diff = targetAmount - current;
 			return {
 				partKey: part.key,
 				partLabel: part.label,
 				type: diff >= 0 ? ('buy' as const) : ('sell' as const),
-				amount: Math.abs(diff)
+				amount: roundUpToWholeCurrency(Math.abs(diff))
 			};
 		})
 		.filter((action) => action.amount > 0);


### PR DESCRIPTION
Rebalancing amounts are now rounded up (ceil) to the nearest whole currency unit instead of the nearest cent, so applying a plan never leaves a part slightly under target. Currency formatting also drops fraction digits entirely so no amount is ever displayed with cents.

Fixes #28.

Generated with [Claude Code](https://claude.ai/code)