### PR TITLE
Fix rebalance not reflecting holdings restored on page reload

### DIFF
--- a/src/lib/components/HoldingsRow.svelte
+++ b/src/lib/components/HoldingsRow.svelte
@@ -22,7 +22,18 @@
 	<span class="name">{part.label}</span>
 	<span class="input-group">
 		<span class="currency-symbol">{currencySymbol}</span>
-		<input type="number" inputmode="decimal" min="0" step="0.01" bind:value oninput={handleInput} />
+		<!-- Without this, some browsers restore this field's value from before a page reload
+		     directly on the DOM node, silently out of sync with the (correctly reloaded)
+		     `value` above, since that restore never fires an input/change event. -->
+		<input
+			type="number"
+			inputmode="decimal"
+			min="0"
+			step="0.01"
+			autocomplete="off"
+			bind:value
+			oninput={handleInput}
+		/>
 	</span>
 </label>
 


### PR DESCRIPTION
## Summary
- Reloading the page with previously-entered holdings could leave the holdings input fields showing a browser-restored value that's out of sync with the app's own state, so the rebalance computation wouldn't reflect what's visibly in the fields.
- Added `autocomplete="off"` to the holdings input in `HoldingsRow.svelte` so the browser no longer restores/overrides the field's value on reload, keeping the app's own state authoritative.

Fixes #31.

## Test plan
- [ ] Enter holdings, reload the page, confirm the rebalance list matches the displayed field values immediately, without needing to touch any input first.
- [ ] `npm run lint` / `npm run check` / `npm run test` (could not be run in the sandboxed environment that produced this PR).

Generated with [Claude Code](https://claude.ai/code)