### PR TITLE
fix: right-align amounts in rebalance action list

### DIFF
--- a/src/lib/components/HoldingsRow.svelte
+++ b/src/lib/components/HoldingsRow.svelte
@@ -59,6 +59,7 @@
 		border-radius: 0.5rem;
 		font: inherit;
 		text-align: right;
+		font-variant-numeric: tabular-nums;
 		appearance: textfield;
 		-webkit-appearance: textfield;
 		-moz-appearance: textfield;

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -90,8 +90,13 @@
 					<ul class="actions">
 						{#each activeActions as action (action.partKey)}
 							<li>
-								{action.type === 'buy' ? 'Buy' : 'Sell'}
-								{formatCurrency(action.amount, currencySelection.id)} of {action.partLabel}
+								<span class="action-label"
+									>{action.type === 'buy' ? 'Buy' : 'Sell'}
+									{action.partLabel}</span
+								>
+								<span class="action-amount"
+									>{formatCurrency(action.amount, currencySelection.id)}</span
+								>
 							</li>
 						{/each}
 					</ul>
@@ -162,6 +167,25 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.375rem;
+	}
+
+	.actions li {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 0.75rem;
+	}
+
+	.action-label {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.action-amount {
+		flex-shrink: 0;
+		text-align: right;
+		font-variant-numeric: tabular-nums;
 	}
 
 	.apply {


### PR DESCRIPTION
Right-aligns currency amounts in the rebalance action list so they form a consistent column instead of landing at varying horizontal positions depending on label/ETF-name length. Also adds tabular-nums to amount displays for consistent digit widths.

Fixes #30.

Generated with [Claude Code](https://claude.ai/code)