### PR TITLE
Add custom naming for portfolio parts (US-13)

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -9,7 +9,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 - [x] **US-1**: As a first-time user, I can choose a portfolio template (50/30/20 or 70/30) so the app knows my target allocation.
 - [x] **US-2**: As a user, my chosen template is saved persistently (offline-capable, survives app restarts) so I don't have to re-select it every visit.
 - [x] **US-3**: As a returning user with a saved template, I skip onboarding and go straight to my portfolio view.
-- [ ] **US-13**: As a user, I can give each part of my split a name of my own choosing, saved persistently, so I still recognize what each allocation represents even after not checking my portfolio for a long time.
+- [x] **US-13**: As a user, I can give each part of my split a name of my own choosing, saved persistently, so I still recognize what each allocation represents even after not checking my portfolio for a long time.
 - [x] **US-14**: As a user, I can choose my currency (Euro or US Dollar) on the onboarding screen, saved persistently, with Euro as the default, so my amounts are shown in the currency I actually use.
 - [x] **US-16**: As a user, I see a short description of each portfolio template on the selection screen explaining its rationale (e.g. why 50/30/20 splits allocations the way it does), so I can pick the template that matches my investing philosophy.
 

--- a/src/lib/components/HoldingsRow.svelte
+++ b/src/lib/components/HoldingsRow.svelte
@@ -4,6 +4,7 @@
 	import type { PortfolioPart } from '$lib/portfolio';
 	import { currencySelection } from '$lib/state/currency.svelte';
 	import { portfolioHoldings } from '$lib/state/holdings.svelte';
+	import { partNames } from '$lib/state/part-names.svelte';
 
 	let { part }: { part: PortfolioPart } = $props();
 
@@ -16,10 +17,48 @@
 	function handleInput() {
 		portfolioHoldings.setAmount(part.key, Number.isFinite(value) ? (value as number) : 0);
 	}
+
+	let editingName = $state(false);
+	let nameDraft = $state('');
+
+	function startEditingName() {
+		nameDraft = partNames.nameFor(part);
+		editingName = true;
+	}
+
+	function commitNameEdit() {
+		// Guards against a stray blur firing after Escape already cancelled the edit.
+		if (!editingName) return;
+		partNames.setName(part.key, nameDraft);
+		editingName = false;
+	}
+
+	function handleNameKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			commitNameEdit();
+		} else if (event.key === 'Escape') {
+			editingName = false;
+		}
+	}
 </script>
 
-<label class="row">
-	<span class="name">{part.label}</span>
+<div class="row">
+	{#if editingName}
+		<input
+			class="name-input"
+			type="text"
+			autocomplete="off"
+			aria-label="Name for {part.label}"
+			bind:value={nameDraft}
+			onblur={commitNameEdit}
+			onkeydown={handleNameKeydown}
+			autofocus
+		/>
+	{:else}
+		<button type="button" class="name" onclick={startEditingName}>
+			{partNames.nameFor(part)}
+		</button>
+	{/if}
 	<span class="input-group">
 		<span class="currency-symbol">{currencySymbol}</span>
 		<!-- Without this, some browsers restore this field's value from before a page reload
@@ -35,7 +74,7 @@
 			oninput={handleInput}
 		/>
 	</span>
-</label>
+</div>
 
 <style>
 	.row {
@@ -47,7 +86,29 @@
 	}
 
 	.name {
+		background: none;
+		border: none;
+		border-bottom: 1px dashed transparent;
+		padding: 0;
+		font: inherit;
 		color: #0f172a;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.name:hover,
+	.name:focus-visible {
+		border-bottom-color: #94a3b8;
+	}
+
+	.name-input {
+		flex: 1;
+		min-width: 0;
+		font: inherit;
+		color: #0f172a;
+		border: 1px solid #cbd5e1;
+		border-radius: 0.375rem;
+		padding: 0.125rem 0.375rem;
 	}
 
 	.input-group {
@@ -63,7 +124,7 @@
 		pointer-events: none;
 	}
 
-	input {
+	.input-group input {
 		width: 8rem;
 		padding: 0.375rem 0.5rem 0.375rem 1.5rem;
 		border: 1px solid #cbd5e1;
@@ -76,8 +137,8 @@
 		-moz-appearance: textfield;
 	}
 
-	input::-webkit-outer-spin-button,
-	input::-webkit-inner-spin-button {
+	.input-group input::-webkit-outer-spin-button,
+	.input-group input::-webkit-inner-spin-button {
 		-webkit-appearance: none;
 		margin: 0;
 	}

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -7,9 +7,15 @@
 	import { buyOnlyActions, sellAndRebuyMinimalActions } from '$lib/rebalance';
 	import { currencySelection } from '$lib/state/currency.svelte';
 	import { portfolioHoldings } from '$lib/state/holdings.svelte';
+	import { partNames } from '$lib/state/part-names.svelte';
 	import { templateSelection } from '$lib/state/portfolio-template.svelte';
 
 	const template = $derived(templateSelection.id ? getTemplate(templateSelection.id) : undefined);
+	// Rebalance actions carry the template's default part label; resolve the
+	// user's custom name (if any) by part key instead of trusting it verbatim.
+	const partLabelByKey = $derived(
+		new Map(template?.parts.map((part) => [part.key, partNames.nameFor(part)]) ?? [])
+	);
 	const buyActions = $derived(template ? buyOnlyActions(template, portfolioHoldings.all) : []);
 	// Sells listed above buys within the sell-and-rebuy plan.
 	const sellAndRebuyActions = $derived(
@@ -92,7 +98,7 @@
 							<li>
 								<span class="action-label"
 									>{action.type === 'buy' ? 'Buy' : 'Sell'}
-									{action.partLabel}</span
+									{partLabelByKey.get(action.partKey) ?? action.partLabel}</span
 								>
 								<span class="action-amount"
 									>{formatCurrency(action.amount, currencySelection.id)}</span

--- a/src/lib/state/part-names.svelte.ts
+++ b/src/lib/state/part-names.svelte.ts
@@ -1,0 +1,40 @@
+import { browser } from '$app/environment';
+import type { PortfolioPart } from '$lib/portfolio';
+
+const STORAGE_KEY = 'stblzr:part-names';
+
+function readStored(): Record<string, string> {
+	if (!browser) return {};
+	const raw = localStorage.getItem(STORAGE_KEY);
+	if (!raw) return {};
+	try {
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed === 'object') return parsed;
+	} catch {
+		// malformed data from an older version or manual tampering - fall back to empty
+	}
+	return {};
+}
+
+let customNames = $state<Record<string, string>>(readStored());
+
+export const partNames = {
+	nameFor(part: PortfolioPart): string {
+		return customNames[part.key]?.trim() || part.label;
+	},
+	// An empty (or whitespace-only) name clears the override, reverting to the
+	// template's default label rather than persisting a blank name.
+	setName(partKey: string, name: string) {
+		const trimmed = name.trim();
+		const next = { ...customNames };
+		if (trimmed) {
+			next[partKey] = trimmed;
+		} else {
+			delete next[partKey];
+		}
+		customNames = next;
+		if (browser) {
+			localStorage.setItem(STORAGE_KEY, JSON.stringify(customNames));
+		}
+	}
+};

--- a/src/lib/state/part-names.test.ts
+++ b/src/lib/state/part-names.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import type { PortfolioPart } from '../portfolio';
+import { partNames } from './part-names.svelte';
+
+describe('partNames', () => {
+	it('falls back to the part label when no custom name is set', () => {
+		const part: PortfolioPart = { key: 'a', label: 'World', targetPct: 50 };
+		expect(partNames.nameFor(part)).toBe('World');
+	});
+
+	it('returns the custom name after it is set', () => {
+		const part: PortfolioPart = { key: 'b', label: 'World', targetPct: 50 };
+		partNames.setName('b', 'My Growth Bucket');
+		expect(partNames.nameFor(part)).toBe('My Growth Bucket');
+	});
+
+	it('falls back to the label again when the custom name is cleared', () => {
+		const part: PortfolioPart = { key: 'c', label: 'Europe', targetPct: 20 };
+		partNames.setName('c', 'Temp');
+		partNames.setName('c', '   ');
+		expect(partNames.nameFor(part)).toBe('Europe');
+	});
+
+	it('trims whitespace from custom names', () => {
+		const part: PortfolioPart = { key: 'd', label: 'World', targetPct: 50 };
+		partNames.setName('d', '  Padded  ');
+		expect(partNames.nameFor(part)).toBe('Padded');
+	});
+});


### PR DESCRIPTION
Implements US-13: users can tap a part's name in the holdings list to give it a custom, persistent name, shown wherever that part's label is displayed (holdings list, rebalance actions).

Closes #34.

Generated with [Claude Code](https://claude.ai/code)