### PR TITLE
Fix white bar at bottom of screen in PWA mode

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,14 @@
 	let { children } = $props();
 
 	const theme = $derived(getTheme(themeSelection.id));
+
+	// In standalone/PWA mode, iOS paints the safe-area and overscroll regions using
+	// <html>'s own background rather than any descendant element's - without this, a
+	// gap there (e.g. below the fixed-height app shell) shows through as a stray white
+	// bar instead of the theme's background.
+	$effect(() => {
+		document.documentElement.style.background = theme.bg;
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,18 +6,17 @@
 	let { children } = $props();
 
 	const theme = $derived(getTheme(themeSelection.id));
-
-	// In standalone/PWA mode, iOS paints the safe-area and overscroll regions using
-	// <html>'s own background rather than any descendant element's - without this, a
-	// gap there (e.g. below the fixed-height app shell) shows through as a stray white
-	// bar instead of the theme's background.
-	$effect(() => {
-		document.documentElement.style.background = theme.bg;
-	});
 </script>
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
+	<!-- In standalone/PWA mode, iOS paints the safe-area and overscroll regions using
+	     <html>'s own background rather than any descendant element's - without this, a
+	     gap there (e.g. below the fixed-height app shell) shows through as a stray white
+	     bar instead of the theme's background. Rendered here (rather than set via an
+	     $effect) so it's applied as part of the initial render, avoiding a flash of white. -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -- theme.bg is a hardcoded hex value from src/lib/themes.ts, not user input -->
+	{@html `<style>html{background:${theme.bg}}</style>`}
 </svelte:head>
 
 <div


### PR DESCRIPTION
Fixes #40.

In standalone/PWA mode on iOS, the safe-area/overscroll regions are painted using <html>'s own background, not a descendant element's. The theme background was only ever applied to the nested .theme-root div, so any uncovered strip fell back to the browser's default white. This syncs the active theme's background onto document.documentElement so it always matches.

Generated with [Claude Code](https://claude.ai/code)