### PR TITLE
Close PWA bottom safe-area gap instead of recoloring it

### DIFF
--- a/src/lib/components/AppScreen.svelte
+++ b/src/lib/components/AppScreen.svelte
@@ -6,7 +6,15 @@
 	let { title, children }: { title: string; children: Snippet } = $props();
 </script>
 
-<div class="screen" style:top="{viewportSize.offsetTop}px" style:height="{viewportSize.height}px">
+<!-- visualViewport.height (what viewportSize.height tracks) excludes the bottom safe
+     area even in standalone/PWA mode with viewport-fit=cover, unlike the 100dvh CSS
+     fallback below - without adding it back, the shell falls short of the real bottom
+     edge, leaving a gap iOS fills with <html>'s own background instead of ours. -->
+<div
+	class="screen"
+	style:top="{viewportSize.offsetTop}px"
+	style:height="calc({viewportSize.height}px + env(safe-area-inset-bottom))"
+>
 	<AppHeader {title} />
 	<div class="scroll-area">
 		{@render children()}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,13 +10,15 @@
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
-	<!-- In standalone/PWA mode, iOS paints the safe-area and overscroll regions using
-	     <html>'s own background rather than any descendant element's - without this, a
-	     gap there (e.g. below the fixed-height app shell) shows through as a stray white
-	     bar instead of the theme's background. Rendered here (rather than set via an
+	<!-- iOS paints the safe-area/overscroll regions using <html>'s own background rather
+	     than any descendant element's, so a gap there would otherwise show through as a
+	     stray white bar. AppScreen.svelte's shell already extends into the bottom safe
+	     area (via env(safe-area-inset-bottom)) in PWA/standalone mode, closing that gap
+	     entirely there - so this fallback paint is scoped to plain-browser-tab Safari,
+	     where the shell doesn't extend that far. Rendered here (rather than via an
 	     $effect) so it's applied as part of the initial render, avoiding a flash of white. -->
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- theme.bg is a hardcoded hex value from src/lib/themes.ts, not user input -->
-	{@html `<style>html{background:${theme.bg}}</style>`}
+	{@html `<style>@media not all and (display-mode: standalone) { html { background: ${theme.bg} } }</style>`}
 </svelte:head>
 
 <div


### PR DESCRIPTION
Closes the layout gap that caused the bottom safe-area bar in PWA/standalone mode on iOS, instead of recoloring it to match the theme.

- `AppScreen.svelte`: extend the fixed-height app shell by `env(safe-area-inset-bottom)`, since `visualViewport.height` excludes the safe area even with `viewport-fit=cover`.
- `+layout.svelte`: scope the #40 html-background fallback to `display-mode: standalone` being false, i.e. plain Safari tabs only, since the shell fix makes it unnecessary in PWA mode.

Fixes #42.

Generated with [Claude Code](https://claude.ai/code)