### PR TITLE
Color PWA bottom safe-area fallback to match header

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,13 +12,20 @@
 	<link rel="icon" href={favicon} />
 	<!-- iOS paints the safe-area/overscroll regions using <html>'s own background rather
 	     than any descendant element's, so a gap there would otherwise show through as a
-	     stray white bar. AppScreen.svelte's shell already extends into the bottom safe
-	     area (via env(safe-area-inset-bottom)) in PWA/standalone mode, closing that gap
-	     entirely there - so this fallback paint is scoped to plain-browser-tab Safari,
-	     where the shell doesn't extend that far. Rendered here (rather than via an
-	     $effect) so it's applied as part of the initial render, avoiding a flash of white. -->
-	<!-- eslint-disable-next-line svelte/no-at-html-tags -- theme.bg is a hardcoded hex value from src/lib/themes.ts, not user input -->
-	{@html `<style>@media not all and (display-mode: standalone) { html { background: ${theme.bg} } }</style>`}
+	     stray white bar. AppScreen.svelte's shell tries to extend into the bottom safe
+	     area (via env(safe-area-inset-bottom)) in PWA/standalone mode, but that depends on
+	     visualViewport reporting accurately, which isn't reliable on every device - so, as
+	     a backstop, standalone mode also gets this fallback, painted with the header's own
+	     color (accentDark, the bottom end of its gradient) rather than the page bg, since
+	     any gap that slips through sits directly below the header. Plain-browser-tab Safari
+	     keeps using the page bg, matching scrollable content instead. Rendered here (rather
+	     than via an $effect) so it's applied as part of the initial render, avoiding a flash
+	     of the wrong color. -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -- theme.bg/accentDark are hardcoded hex values from src/lib/themes.ts, not user input -->
+	{@html `<style>
+		@media not all and (display-mode: standalone) { html { background: ${theme.bg} } }
+		@media (display-mode: standalone) { html { background: ${theme.accentDark} } }
+	</style>`}
 </svelte:head>
 
 <div


### PR DESCRIPTION
Fixes #44.

PR #43 tried to close the PWA bottom safe-area gap by extending the app shell's height, but that depends on `visualViewport` reporting accurately, which isn't reliable on every device, so a gap can still show through. This adds a standalone/PWA-mode fallback that paints <html>'s background with the header's `accentDark` color, so any residual gap matches the top bar instead of standing out.

Generated with [Claude Code](https://claude.ai/code)