### PR TITLE
Add copy-to-clipboard button for rebalancing amounts

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -38,6 +38,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
 - [x] **US-16**: As a user, I pick one rebalancing option at a time via side-by-side buttons and act on it with a single Apply button, rather than seeing both options with their own Apply buttons at once; within the sell-and-rebuy plan, sells are listed above buys.
 - [x] **US-17**: As a user, buy and sell amounts in a rebalancing plan are always whole currency units - if the exact target math would need cents, the amount is rounded up so applying the plan never leaves me short of target.
 - [x] **US-20**: As a user, I see a total row under a rebalancing plan's line items (total to invest for buy-only, total to move for buy-and-sell), so I don't have to add up the individual actions myself.
+- [x] **US-24**: As a user, I can tap a small copy icon next to a rebalancing action's amount to copy the raw number (no currency symbol or separators) to my clipboard, so I can paste it directly into my broker's app.
 
 ## Backlog / not yet scoped
 

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -70,6 +70,18 @@
 		}
 		holdingsVersion += 1;
 	}
+
+	// Briefly identifies the action whose amount was just copied, so the icon
+	// can show a checkmark for a moment as feedback. Cleared after a short delay.
+	let copiedPartKey = $state<string | null>(null);
+
+	async function copyAmount(action: { partKey: string; amount: number }) {
+		await navigator.clipboard.writeText(String(action.amount));
+		copiedPartKey = action.partKey;
+		setTimeout(() => {
+			if (copiedPartKey === action.partKey) copiedPartKey = null;
+		}, 1500);
+	}
 </script>
 
 <AppScreen title="Your portfolio">
@@ -135,9 +147,65 @@
 									{action.type === 'buy' ? 'Buy' : 'Sell'}
 									{partLabelByKey.get(action.partKey) ?? action.partLabel}
 								</span>
-								<span class="action-amount"
-									>{formatCurrency(action.amount, currencySelection.id)}</span
-								>
+								<span class="action-amount-group">
+									<span class="action-amount"
+										>{formatCurrency(action.amount, currencySelection.id)}</span
+									>
+									<button
+										type="button"
+										class="copy-button"
+										aria-label="Copy {action.amount} to clipboard"
+										onclick={() => copyAmount(action)}
+									>
+										{#if copiedPartKey === action.partKey}
+											<svg
+												viewBox="0 0 20 20"
+												width="14"
+												height="14"
+												aria-hidden="true"
+												focusable="false"
+											>
+												<path
+													d="M4 10.5l4 4 8-9"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="1.75"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										{:else}
+											<svg
+												viewBox="0 0 20 20"
+												width="14"
+												height="14"
+												aria-hidden="true"
+												focusable="false"
+											>
+												<rect
+													x="7"
+													y="3"
+													width="9"
+													height="12"
+													rx="1.25"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="1.5"
+												/>
+												<rect
+													x="4"
+													y="6"
+													width="9"
+													height="12"
+													rx="1.25"
+													fill="var(--surface)"
+													stroke="currentColor"
+													stroke-width="1.5"
+												/>
+											</svg>
+										{/if}
+									</button>
+								</span>
 							</li>
 						{/each}
 					</ul>
@@ -263,10 +331,41 @@
 		align-self: center;
 	}
 
-	.action-amount {
+	.action-amount-group {
 		flex-shrink: 0;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.action-amount {
 		text-align: right;
 		font-variant-numeric: tabular-nums;
+	}
+
+	.copy-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.25rem;
+		height: 1.25rem;
+		padding: 0;
+		background: none;
+		border: none;
+		border-radius: 0.25rem;
+		color: var(--text-muted);
+		cursor: pointer;
+		box-shadow: none;
+	}
+
+	.copy-button:hover {
+		background: var(--surface-alt);
+		filter: none;
+	}
+
+	.copy-button:active {
+		box-shadow: none;
+		transform: none;
 	}
 
 	.total-row {

--- a/src/lib/components/PortfolioView.svelte
+++ b/src/lib/components/PortfolioView.svelte
@@ -73,13 +73,17 @@
 
 	// Briefly identifies the action whose amount was just copied, so the icon
 	// can show a checkmark for a moment as feedback. Cleared after a short delay.
-	let copiedPartKey = $state<string | null>(null);
+	// Keyed by plan + part key, since the same part key appears in both the
+	// "buy only" and "sell and rebuy" plans with different amounts.
+	let copiedActionKey = $state<string | null>(null);
+	const actionKey = (action: { partKey: string }) => `${selectedOption}:${action.partKey}`;
 
 	async function copyAmount(action: { partKey: string; amount: number }) {
 		await navigator.clipboard.writeText(String(action.amount));
-		copiedPartKey = action.partKey;
+		const key = actionKey(action);
+		copiedActionKey = key;
 		setTimeout(() => {
-			if (copiedPartKey === action.partKey) copiedPartKey = null;
+			if (copiedActionKey === key) copiedActionKey = null;
 		}, 1500);
 	}
 </script>
@@ -157,7 +161,7 @@
 										aria-label="Copy {action.amount} to clipboard"
 										onclick={() => copyAmount(action)}
 									>
-										{#if copiedPartKey === action.partKey}
+										{#if copiedActionKey === actionKey(action)}
 											<svg
 												viewBox="0 0 20 20"
 												width="14"


### PR DESCRIPTION
Adds a small copy icon next to each buy/sell amount in the Rebalance section that copies the raw, unformatted number to the clipboard (no currency symbol or separators), so it can be pasted directly into a broker app.

Closes #46.

Generated with [Claude Code](https://claude.ai/code)